### PR TITLE
Fix for static file saving

### DIFF
--- a/src/ThumbnailResponder.php
+++ b/src/ThumbnailResponder.php
@@ -177,7 +177,10 @@ class ThumbnailResponder
         $path = urldecode($this->request->getPathInfo());
         try {
             $webroot = dirname($this->request->server->get('SCRIPT_FILENAME'));
-            mkdir(dirname($webroot.$path),0777,true);
+            $savePath = dirname($webroot.$path);
+            if (!is_dir($savePath)) {
+                mkdir($savePath,0777,true);
+            }
             file_put_contents($webroot.$path, $imageContent);
         } catch (\Exception $e) {
 


### PR DESCRIPTION
There is a line where the thumbnailer creates the directory where the static thumbnail file is saved for later use: [ThumbnailResponder.php#L180](https://github.com/bolt/bolt-thumbs/blob/master/src/ThumbnailResponder.php#L180)

According to [PHP manual](http://php.net/manual/en/function.mkdir.php#refsect1-function.mkdir-errors) we need an extra check if the directory exist, otherwise mkdir throws an E_WARNING level error which translated to Excpetion by Bolt and the file will not be saved at the next line because the try catch block.
