### PR TITLE
Add progressive jpegs

### DIFF
--- a/src/ThumbnailCreator.php
+++ b/src/ThumbnailCreator.php
@@ -282,6 +282,7 @@ class ThumbnailCreator implements ResizeInterface
                 imagegif($imageContent);
                 break;
             case 'jpg':
+                imageinterlace($imageContent, 1);
                 imagejpeg($imageContent, null, $this->quality);
                 break;
             case 'png':


### PR DESCRIPTION
Progressive jpegs create a perception of faster loading because you see an image faster. 