### PR TITLE
No valid exif data in image breaks image output

### DIFF
--- a/src/ThumbnailCreator.php
+++ b/src/ThumbnailCreator.php
@@ -176,7 +176,7 @@ class ThumbnailCreator implements ResizeInterface
                 $img = imagecreatefromjpeg($src);
                 // Handle exif orientation
                 if ($this->exifOrientation && function_exists('exif_read_data')) {
-                    $exif = exif_read_data($src);
+                    $exif = @exif_read_data($src);
                 } else {
                     $exif = false;
                 }


### PR DESCRIPTION
JPG images are not necessary contains valid exif data. Image attached below is simply saved from Photoshop with no metadata. Uploading it up in Bolt causes no preview because a E_WARNING message exception:
```
Whoops\Exception\ErrorException thrown with message "exif_read_data(mario.jpg): Incorrect APP1 Exif Identifier Code"

Stacktrace:
#13 Whoops\Exception\ErrorException in /home/rix/bolt.d64/brke/brke-web/vendor/bolt/thumbs/src/ThumbnailCreator.php:179
#12 Whoops\Run:handleError in <#unknown>:0
#11 exif_read_data in /home/rix/bolt.d64/brke/brke-web/vendor/bolt/thumbs/src/ThumbnailCreator.php:179
#10 Bolt\Thumbs\ThumbnailCreator:doResize in /home/rix/bolt.d64/brke/brke-web/vendor/bolt/thumbs/src/ThumbnailCreator.php:123
...
```

I'm not sure it is the best practice to suppress error output by '@' like in this PR.
Image with the issue can be reproduced: https://www.dropbox.com/s/8xhn976vzizc500/mario.jpg?dl=0