### PR TITLE
image aliases added #3703

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor/
 composer.lock
 .DS_*
+.idea
 tests/tmp
 tests/report

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -90,7 +90,7 @@ class Controller implements ControllerProviderInterface
      */
     public function alias(Application $app, Request $request, $file, $alias)
     {
-        $config = $app["config"]->get("theme/image_aliases/".$alias, false);
+        $config = isset($app["thumbnails.aliases"][$alias]) ? $app["thumbnails.aliases"][$alias] : false;
 
         // Set to default 404 image if alias does not exist
         if(!$config) {
@@ -139,7 +139,7 @@ class Controller implements ControllerProviderInterface
      */
     protected function isRestricted(Application $app, Request $request)
     {
-        return $app["config"]->get("general/thumbnails/only_aliases", false);
+        return isset($app["thumbnails.only_aliases"]) ? $app["thumbnails.only_aliases"] : false;
     }
 
     /**
@@ -152,14 +152,15 @@ class Controller implements ControllerProviderInterface
     {
         $requestPath = urldecode($request->getPathInfo());
 
-        $size = $app["config"]->get("general/thumbnails/default_thumbnail");
+        $size = $app['thumbnails.default_imagesize'];
 
         $transaction = new Transaction(
-            $app["config"]->get("general/thumbnails/notfound_image"),
+            $app["thumbnails.default_image"],
             Action::CROP,
             new Dimensions($size[0],$size[1]),
             $requestPath
         );
+
         $thumbnail = $app['thumbnails']->respond($transaction);
 
         return new Response($thumbnail);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -52,7 +52,7 @@ class ServiceProvider implements ServiceProviderInterface
         $app['thumbnails.error_image'] = null;
         $app['thumbnails.cache_time'] = null;
         $app['thumbnails.limit_upscaling'] = true;
-        $app['thumbnails.restrict_alias'] = false;
+        $app['thumbnails.only_aliases'] = false;
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -52,6 +52,7 @@ class ServiceProvider implements ServiceProviderInterface
         $app['thumbnails.error_image'] = null;
         $app['thumbnails.cache_time'] = null;
         $app['thumbnails.limit_upscaling'] = true;
+        $app['thumbnails.restrict_alias'] = false;
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -49,10 +49,12 @@ class ServiceProvider implements ServiceProviderInterface
         $app['thumbnails.cache'] = null;
 
         $app['thumbnails.default_image'] = null;
+        $app['thumbnails.default_imagesize'] = [];
         $app['thumbnails.error_image'] = null;
         $app['thumbnails.cache_time'] = null;
         $app['thumbnails.limit_upscaling'] = true;
         $app['thumbnails.only_aliases'] = false;
+        $app['thumbnails.aliases'] = [];
     }
 
     /**

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -58,6 +58,7 @@ class ControllerTest extends WebTestCase
 
     protected function mockResponder($path, $file, $action, $width, $height)
     {
+
         /** @var \PHPUnit_Framework_MockObject_MockObject $mock */
         $mock = $this->app['thumbnails'];
         $mock->expects($this->once())


### PR DESCRIPTION
This is a first try of doing it as much as the current code base does it while not changing to much of it. Feel free to suggest changes...

There will be a complimenting bolt/bolt PR with the new config values and a sample alias inside the theme.yml
The sample theme.yml will look like this:

```
# Aliases can be set to restrict images to a specific set of available
# resolutions or to decouple image sizes from template files.
image_aliases:
    myimageformat:
        size: [400,300]
        cropping: crop
```

**Note** The twig filters for image and thumbnail are not done yet. They are probably inside bolt and not bolt-thumbs. Will add them asap!