### PR TITLE
Fix only_aliases behaviour to work for backend users

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -74,7 +74,7 @@ class Controller implements ControllerProviderInterface
      */
     public function thumbnail(Application $app, Request $request, $file, $action, $width, $height)
     {
-        // Set to default 404 image if restricted to aliases
+        // Return 403 response if restricted to aliases
         if ($this->isRestricted($app, $request)) {
             $app->abort(Response::HTTP_FORBIDDEN);
         }

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -7,6 +7,7 @@ use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ControllerProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Controller for the thumbnail route.
@@ -75,7 +76,7 @@ class Controller implements ControllerProviderInterface
     {
         // Set to default 404 image if restricted to aliases
         if ($this->isRestricted($app, $request)) {
-            return $this->defaultResponse($app, $request);
+            $app->abort(Response::HTTP_FORBIDDEN);
         }
 
         return $this->serve($app, $request, $file, $action, $width, $height);
@@ -146,6 +147,13 @@ class Controller implements ControllerProviderInterface
      */
     protected function isRestricted(Application $app, Request $request)
     {
+        $session = $request->getSession();
+        $auth = (isset($session)) ? $session->get('authentication') : null;
+
+        if ($auth && ($auth->getUser()->getEnabled())) {
+            return false;
+        }
+
         return isset($app['thumbnails.only_aliases']) ? $app['thumbnails.only_aliases'] : false;
     }
 


### PR DESCRIPTION
OK, hopefully this should improve things.

Modified the `isRestricted` check to see if we have an enabled user set and if so to return `false`

Tests also included.