### PR TITLE
Add the Content-Type header to the Response

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -7,7 +7,6 @@ use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ControllerProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Controller for the thumbnail route.

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace Bolt\Thumbs\Tests;
 
+use Bolt\Filesystem\Adapter\Local;
+use Bolt\Filesystem\Filesystem;
 use Bolt\Filesystem\Handler\Image;
 use Bolt\Filesystem\Handler\Image\Dimensions;
 use Bolt\Thumbs\Controller;
@@ -93,6 +95,11 @@ class ControllerTest extends WebTestCase
         $app->register(new ServiceControllerServiceProvider());
 
         $mock = $this->getMock('Bolt\Thumbs\ThumbnailResponder', ['respond'], [], '', false);
+        $mock
+            ->expects($this->any())
+            ->method('respond')
+            ->willReturn(new Thumbnail(new Image(new Filesystem(new Local(__DIR__))), ''))
+        ;
         $app['thumbnails'] = $mock;
 
         return $app;

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -50,7 +50,7 @@ class ControllerTest extends WebTestCase
         $app['thumbnails.only_aliases'] = false;
         $controller = new Controller();
         $request = Request::create('/thumbs/123x456c/herp/derp.png');
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->thumbnail($app, $request, 'herp/derp.png', 'c', 123, 456));
+        $this->assertInstanceOf('Bolt\Thumbs\Response', $controller->thumbnail($app, $request, 'herp/derp.png', 'c', 123, 456));
 
         $app['thumbnails.only_aliases'] = true;
         $this->setExpectedException('Symfony\Component\HttpKernel\Exception\HttpException');
@@ -79,7 +79,7 @@ class ControllerTest extends WebTestCase
         $request->setSession($session);
 
         $app['thumbnails.only_aliases'] = true;
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->thumbnail($app, $request, 'herp/derp.png', 'c', 123, 456));
+        $this->assertInstanceOf('Bolt\Thumbs\Response', $controller->thumbnail($app, $request, 'herp/derp.png', 'c', 123, 456));
     }
 
     /**


### PR DESCRIPTION
The Response object adds a "Content-Type: text/html" header by default. This header should match the thumbnail's mime type.